### PR TITLE
Improve the implementation of parsing build-cfg.json & copying files with config

### DIFF
--- a/bin/cocos.py
+++ b/bin/cocos.py
@@ -676,13 +676,27 @@ def copy_files_in_dir(src, dst):
                 os.makedirs(add_path_prefix(new_dst))
             copy_files_in_dir(path, new_dst)
 
+def replace_env_variable(the_str):
+    import re
+    env_pattern = '\${(.*)}'
+    match = re.match(env_pattern, the_str)
+    ret = the_str
+    if match:
+        env_key = match.group(1)
+        env_value = check_environment_variable(env_key)
+        ret = ret.replace('${%s}' % env_key, env_value)
+
+    return ret
 
 def copy_files_with_config(config, src_root, dst_root):
-    src_dir = config["from"]
-    dst_dir = config["to"]
+    src_dir = replace_env_variable(config["from"])
+    dst_dir = replace_env_variable(config["to"])
 
-    src_dir = os.path.join(src_root, src_dir)
-    dst_dir = os.path.join(dst_root, dst_dir)
+    if not os.path.isabs(src_dir):
+        src_dir = os.path.normpath(os.path.join(src_root, src_dir))
+
+    if not os.path.isabs(dst_dir):
+        dst_dir = os.path.normpath(os.path.join(dst_root, dst_dir))
 
     include_rules = None
     if "include" in config:

--- a/plugins/plugin_compile/build_android.py
+++ b/plugins/plugin_compile/build_android.py
@@ -277,14 +277,11 @@ class AndroidBuilder(object):
 
         module_paths = []
         for cfg_path in self.ndk_module_paths:
-            if cfg_path.find("${COCOS_X_ROOT}") >= 0:
-                cocos_root = cocos.check_environment_variable("COCOS_X_ROOT")
-                module_paths.append(cfg_path.replace("${COCOS_X_ROOT}", cocos_root))
-            elif cfg_path.find("${COCOS_FRAMEWORKS}") >= 0:
-                cocos_frameworks = cocos.check_environment_variable("COCOS_FRAMEWORKS")
-                module_paths.append(cfg_path.replace("${COCOS_FRAMEWORKS}", cocos_frameworks))
-            else:
-                module_paths.append(os.path.join(self.app_android_root, cfg_path))
+            the_path = cocos.replace_env_variable(cfg_path)
+            if not os.path.isabs(the_path):
+                the_path = os.path.normpath(os.path.join(self.app_android_root, the_path))
+
+            module_paths.append(the_path)
 
         # delete template static and dynamic files
         obj_local_dir = os.path.join(ndk_work_dir, "obj", "local")


### PR DESCRIPTION
1. Support absolute path in config `ndk-module-paths`.
2. Support absolute path & environment variable in copy files config.
