### PR TITLE
Support VS2017 in cocos compile

### DIFF
--- a/bin/utils.py
+++ b/bin/utils.py
@@ -42,24 +42,45 @@ def get_msbuild_path(vs_version):
 
     # Find VS path
     msbuild_path = None
-    for reg_flag in reg_flag_list:
-        try:
-            vs = _winreg.OpenKey(
-                _winreg.HKEY_LOCAL_MACHINE,
-                r"SOFTWARE\Microsoft\MSBuild\ToolsVersions\%s" % vs_ver,
-                0,
-                _winreg.KEY_READ | reg_flag
-            )
-            msbuild_path, type = _winreg.QueryValueEx(vs, 'MSBuildToolsPath')
-        except:
-            continue
+    if vs_ver == '15.0':
+        # Find VS2017 Path Ref:https://stackoverflow.com/questions/328017/path-to-msbuild
+        for reg_flag in reg_flag_list:
+            try:
+                vs = _winreg.OpenKey(
+                    _winreg.HKEY_LOCAL_MACHINE,
+                    r"SOFTWARE\WOW6432Node\Microsoft\VisualStudio\SxS\VS7",
+                    0,
+                    _winreg.KEY_READ | reg_flag
+                )
+                msbuild_path, type = _winreg.QueryValueEx(vs, '15.0')
+            except:
+                continue
 
-        if msbuild_path is not None:
-            msbuild_path = os.path.join(msbuild_path, "MSBuild.exe")
-            if os.path.exists(msbuild_path):
-                break
-            else:
-                msbuild_path = None
+            if msbuild_path is not None:
+                msbuild_path = os.path.join(msbuild_path, "MSBuild\\15.0\\bin\\amd64\\MSBuild.exe")
+                if os.path.exists(msbuild_path):
+                    break
+                else:
+                    msbuild_path = None
+    else:
+        for reg_flag in reg_flag_list:
+            try:
+                vs = _winreg.OpenKey(
+                    _winreg.HKEY_LOCAL_MACHINE,
+                    r"SOFTWARE\Microsoft\MSBuild\ToolsVersions\%s" % vs_ver,
+                    0,
+                    _winreg.KEY_READ | reg_flag
+                )
+                msbuild_path, type = _winreg.QueryValueEx(vs, 'MSBuildToolsPath')
+            except:
+                continue
+
+            if msbuild_path is not None:
+                msbuild_path = os.path.join(msbuild_path, "MSBuild.exe")
+                if os.path.exists(msbuild_path):
+                    break
+                else:
+                    msbuild_path = None
 
     return msbuild_path
 

--- a/plugins/plugin_generate/configs/gen_libs_config.json
+++ b/plugins/plugin_generate/configs/gen_libs_config.json
@@ -36,5 +36,5 @@
         "cocos/editor-support/creator/Android.mk",
         "tools/simulator/libsimulator/proj.android/Android.mk"
     ],
-    "support_vs_versions" : [ 2015, 2013 ]
+    "support_vs_versions" : [ 2017, 2015, 2013 ]
 }

--- a/plugins/plugin_generate/gen_libs.py
+++ b/plugins/plugin_generate/gen_libs.py
@@ -183,7 +183,7 @@ class LibsCompiler(cocos.CCPlugin):
             "\"%s\"" % cmd_path,
             "\"%s\"" % sln_path,
             "/t:%s" % proj_name,
-            "/property:Configuration=%s" % mode,
+            "/property:Configuration=%s;Platform=Win32" % mode,
             "/m"
         ])
         self._run_cmd(build_cmd)
@@ -212,6 +212,7 @@ class LibsCompiler(cocos.CCPlugin):
                 Logging.warning(MultiLanguage.get_string('GEN_LIBS_WARNING_VS_NOT_FOUND_FMT', vs_version))
             else:
                 vs_cmd_info[vs_version] = vs_command
+
 
         if len(vs_cmd_info) == 0:
             raise CCPluginError(MultiLanguage.get_string('GEN_LIBS_ERROR_VS_NOT_FOUND'),
@@ -243,7 +244,7 @@ class LibsCompiler(cocos.CCPlugin):
                     clean_cmd = " ".join([
                         "\"%s\"" % vs_command,
                         "\"%s\"" % proj_path,
-                        "/t:Clean /p:Configuration=%s" % mode_str
+                        "/t:Clean /p:Configuration=%s;Platform=Win32" % mode_str
                     ])
                     self._run_cmd(clean_cmd)
 


### PR DESCRIPTION
test in win10 x64 & vs2017

参考：https://stackoverflow.com/questions/328017/path-to-msbuild
从注册表"HKLM:\SOFTWARE\wow6432node\Microsoft\VisualStudio\SxS\VS7"获取vs2017安装路径拼出msbuild.exe路径
在Win10 x64 和vs2017 企业版中测试通过